### PR TITLE
Change fft backend to FFTW3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/lib/pynlo/utility/chi2.py
 build/lib/pynlo/utility/chi3.py
 build/lib/pynlo/utility/fft.py
 build/lib/pynlo/utility/misc.py
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ Features:
 
 ## Installation
 
-### Installing to Use
+The FFT backend [`FFTW3`](https://www.fftw.org/) makes this version of PyNLO **cross-platform**.
 
-PyNLO is designed to work most easily with the [miniconda](https://docs.conda.io/en/latest/miniconda.html) distribution, but uses [unidep](https://unidep.readthedocs.io/en/latest/index.html) to allow compatibility with `pip`. For a minimal install using `conda`, run,
+### Installing to Use
+#### Installing with `conda`
+
+PyNLO is designed to work most easily with the [miniconda](https://docs.conda.io/en/latest/miniconda.html) distribution. For a functional installation with `conda`, run,
 
     git clone https://github.com/UCBoulder/PyNLO.git
     cd pynlo
@@ -29,9 +32,14 @@ PyNLO is designed to work most easily with the [miniconda](https://docs.conda.io
     unidep install -n pynlo .
     conda activate pynlo
 
-to clone this repo to your machine and install it in a new `conda` environment named `pynlo`. Test out your installation with the scripts in the examples folder. These also require the `matplotlib` package.
+This command clones the repo to your machine and installs it in a new `conda` environment named `pynlo`. Test out your installation with the scripts in the examples folder. 
+
+#### Installing with `pip`
+
+PyNLO is designed to use with `conda` but uses [`unidep`](https://unidep.readthedocs.io/en/latest/index.html) for packaging, which has compatibility with `pip`. However, PyNLO relies on [`FFTW3`](https://www.fftw.org/), which does not ship with the `pip` distribution of `pyfftw` by default. This must be installed separately, so using `conda` (which has `FFTW3` packaged with it) is highly recommended. 
 
 ### Installing to Develop
+
 
 If you're looking to make changes to the source code of `pynlo`, add the `-e` flag so that changes made on the local version of the repository are reflected in your local scripts:
 

--- a/pynlo/__init__.py
+++ b/pynlo/__init__.py
@@ -11,7 +11,7 @@ PyNLO is intended to be used with all quantities expressed in base SI units,
 i.e. frequency in ``Hz``, time in ``s``, and energy in ``J``.
 
 """
-__version__ = '1.dev'
+__version__ = '0.2.3'
 __all__ = ["light", "medium", "device", "model", "utility"]
 
 

--- a/pynlo/utility/__init__.py
+++ b/pynlo/utility/__init__.py
@@ -21,6 +21,7 @@ import copy
 
 import numpy as np
 from scipy.constants import pi, h
+from scipy.special import factorial
 
 from pynlo.utility import chi1, chi2, chi3, fft
 
@@ -60,7 +61,7 @@ def taylor_series(x0, fn):
     """
     window = np.array([-1, 1])
     domain = window + x0
-    poly_coefs = [coef/np.math.factorial(n) for (n, coef) in enumerate(fn)]
+    poly_coefs = [coef/factorial(n) for (n, coef) in enumerate(fn)]
     pwr_series = np.polynomial.Polynomial(poly_coefs, domain=domain, window=window)
     return pwr_series
 

--- a/pynlo/utility/fft.py
+++ b/pynlo/utility/fft.py
@@ -4,73 +4,38 @@ Aliases to fast FFT implementations and associated helper functions.
 
 """
 
-__all__ = ["fft", "ifft", "rfft", "irfft",
-           "fftshift", "ifftshift"]
+# __all__ = ["fft", "ifft", "rfft", "irfft",
+        #    "fftshift", "ifftshift"]
 
 
 # %% Imports
 
-from scipy.fft import next_fast_len, fftshift as _fftshift, ifftshift as _ifftshift
-import mkl_fft
+import os
+from scipy.fft import next_fast_len, fftshift, ifftshift 
 
+try:
+    import pyfftw.interfaces.scipy_fft as backend
+    import scipy.fft as _fft
+    _fft.set_global_backend(backend)
 
-# %% Helper Functions
+    import pyfftw
+    pyfftw.interfaces.cache.enable()
+    pyfftw.config.NUM_THREADS = os.cpu_count()
+    print('Using FFTW FFT backend')
 
-#---- FFT Shifts
-def fftshift(x, axis=-1):
-    """
-    Shift the origin from the beginning to the center of the array.
-
-    This function is used after an `fft` operation to shift from fft to monotic
-    ordering.
-
-    Parameters
-    ----------
-    x : array_like
-        Input array
-    axis : int, optional
-        The axis over which to shift. The default is the last axis.
-
-    Returns
-    -------
-    ndarray
-        The shifted array.
-
-    """
-    return _fftshift(x, axes=axis)
-
-def ifftshift(x, axis=-1):
-    """
-    Shift the origin from the center to the beginning of the array.
-
-    The inverse of fftshift. This function is used before an `fft` operation to
-    shift from monotonic to fft ordering. Although identical for even-length
-    `x`, `ifftshift` differs from `fftshift` by one sample for odd-length `x`.
-
-    Parameters
-    ----------
-    x : array_like
-        Input array.
-    axis : int, optional
-        The axis over which to shift. The default is the last axis.
-
-    Returns
-    -------
-    ndarray
-        The shifted array.
-
-    """
-    return _ifftshift(x, axes=axis)
+except ImportError:
+    import scipy.fft as _fft
+    print('Using Scipy FFT backend')
 
 
 # %% Transforms
-
-#---- FFTs
+# 
+# ---- FFTs
 def fft(x, fsc=1.0, n=None, axis=-1, overwrite_x=False):
     """
     Use MKL to perform a 1D FFT of the input array along the given axis.
 
-    Parameters
+    # 
     ----------
     x : array_like
         Input array, can be complex.
@@ -92,8 +57,8 @@ def fft(x, fsc=1.0, n=None, axis=-1, overwrite_x=False):
         The transformed array.
 
     """
-    return mkl_fft.fft(x, n=n, axis=axis, overwrite_x=overwrite_x, fwd_scale=fsc)
-
+    return fsc * _fft.fft(x, n=n, axis=axis, overwrite_x=overwrite_x, norm='backward')
+# 
 def ifft(x, fsc=1.0, n=None, axis=-1, overwrite_x=False):
     """
     Use MKL to perform a 1D IFFT of the input array along the given axis.
@@ -122,9 +87,9 @@ def ifft(x, fsc=1.0, n=None, axis=-1, overwrite_x=False):
         The transformed array.
 
     """
-    return mkl_fft.ifft(x, n=n, axis=axis, overwrite_x=overwrite_x, fwd_scale=fsc)
+    return 1/fsc * _fft.ifft(x, n=n, axis=axis, overwrite_x=overwrite_x, norm='backward')
 
-#---- Real FFTs
+# ---- Real FFTs
 def rfft(x, fsc=1.0, n=None, axis=-1):
     """
     Use MKL to perform a 1D FFT of the real input array along the given axis.
@@ -151,8 +116,8 @@ def rfft(x, fsc=1.0, n=None, axis=-1):
         The transformed array.
 
     """
-    return mkl_fft.rfft(x, n=n, axis=axis, fwd_scale=fsc)
-
+    return fsc * _fft.rfft(x, n=n, axis=axis, norm='backward')
+# 
 def irfft(x, fsc=1.0, n=None, axis=-1):
     """
     Use MKL to perform a 1D IFFT of the input array along the given axis. The
@@ -185,4 +150,4 @@ def irfft(x, fsc=1.0, n=None, axis=-1):
         The transformed array.
 
     """
-    return mkl_fft.irfft(x, n=n, axis=axis, fwd_scale=fsc)
+    return 1/fsc * _fft.irfft(x, n=n, axis=axis, norm='backward')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,6 @@ name = "pynlo"
 description = "Python nonlinear optics"
 readme = "README.md"
 license = {file = "COPYING.LESSER.txt"}
-dependencies = [
-    "numpy>=1,<2",
-    "scipy>=1,<2",
-    "numba<1",
-    "mkl_fft>=1.3,<2"
-]
-
 dynamic = ["version"]
 
 [tool.setuptools.dynamic]
@@ -27,9 +20,11 @@ version = {attr = "pynlo.__version__"}
 channels = ["conda-forge"]
 
 dependencies = [
-    "python>=3.12,<3.13",
-    "numpy>=1,<2",
+    "python>=3.14,<3.15",
+    "numpy>=2,<3",
     "scipy>=1,<2",
     "numba<1",
-    { conda = "mkl_fft>=1.3,<2", pip = "mkl-fft>=1.3,<2" }
+    "pyfftw=0.15.1",
+    "matplotlib"
+
 ]


### PR DESCRIPTION
### Changes 
- Changes FFT backends from `mkl-fft` (Intel proprietary) to `FFTW3` (Fixes #5)
- Upgrade from `python` 3.12 to 3.14
- Upgrades dependencies to latest versions
- README is now more explicit in the need for `conda`
